### PR TITLE
allow downloading llama huggingface model

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,12 @@ Official implementation of **QuanTA**: Efficient High-Rank Fine-Tuning of LLMs w
 
  ```bash
 git clone https://github.com/quanta-fine-tuning/quanta.git
- ```
- ```bash
 cd quanta/quanta/
- ```
- ```bash
 pip install -e .
- ```
- ```bash
 pip install wandb datasets accelerate sentencepiece opt_einsum
- ```
- ```bash
 cd ../run/
- ```
- ```bash
+# complete llama signup at https://huggingface.co/meta-llama/Llama-2-7b-hf
+# and get HF token from https://huggingface.co/settings/tokens
+export HF_TOKEN=<your-huggingface-read-token>
 bash run.sh
- ```
-
-
+```

--- a/quanta/quanta/peft_model.py
+++ b/quanta/quanta/peft_model.py
@@ -23,7 +23,7 @@ import torch
 from accelerate import dispatch_model, infer_auto_device_map
 from accelerate.hooks import AlignDevicesHook, add_hook_to_module, remove_hook_from_submodules
 from accelerate.utils import get_balanced_memory
-from huggingface_hub import hf_hub_download
+from huggingface_hub import hf_hub_download, login
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 from transformers import PreTrainedModel
 from transformers.modeling_outputs import SequenceClassifierOutput, TokenClassifierOutput
@@ -131,6 +131,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             filename = os.path.join(model_id, WEIGHTS_NAME)
         else:
             try:
+                login(os.environ['HF_TOKEN'])
                 filename = hf_hub_download(model_id, WEIGHTS_NAME)
             except:  # noqa
                 raise ValueError(

--- a/quanta/quanta/utils/config.py
+++ b/quanta/quanta/utils/config.py
@@ -19,7 +19,7 @@ import os
 from dataclasses import asdict, dataclass, field
 from typing import Optional, Union
 
-from huggingface_hub import hf_hub_download
+from huggingface_hub import hf_hub_download, login
 from transformers.utils import PushToHubMixin
 
 from .adapters_utils import CONFIG_NAME
@@ -100,6 +100,7 @@ class PeftConfigMixin(PushToHubMixin):
             config_file = os.path.join(pretrained_model_name_or_path, CONFIG_NAME)
         else:
             try:
+                login(os.environ['HF_TOKEN'])
                 config_file = hf_hub_download(pretrained_model_name_or_path, CONFIG_NAME)
             except Exception:
                 raise ValueError(f"Can't find config.json at '{pretrained_model_name_or_path}'")


### PR DESCRIPTION
Without setting up a HuggingFace token and sharing info with Meta for the Llama model, the repo is gated and will error, this change allows using `HF_TOKEN` env [variable](https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hftoken) to login to HF and access the model.
 
```
Cannot access gated repo for url https://huggingface.co/meta-llama/Llama-2-7b-hf/resolve/main/config.json.
Your request to access model meta-llama/Llama-2-7b-hf is awaiting a review from the repo authors.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/samy/code/q/quanta/run/run.py", line 485, in <module>
    main()
  File "/home/samy/code/q/quanta/run/run.py", line 457, in main
    framework = Framework(args, task)
                ^^^^^^^^^^^^^^^^^^^^^
  File "/home/samy/code/q/quanta/run/run.py", line 120, in __init__
    self.model, self.tokenizer = self.load_model()
                                 ^^^^^^^^^^^^^^^^^
  File "/home/samy/code/q/quanta/run/run.py", line 124, in load_model
    config = AutoConfig.from_pretrained(self.args.model_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/samy/code/llama/llama/lib/python3.12/site-packages/transformers/models/auto/configuration_auto.py", line 1006, in from_pretrained
    config_dict, unused_kwargs = PretrainedConfig.get_config_dict(pretrained_model_name_or_path, **kwargs)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/samy/code/llama/llama/lib/python3.12/site-packages/transformers/configuration_utils.py", line 570, in get_config_dict
    config_dict, kwargs = cls._get_config_dict(pretrained_model_name_or_path, **kwargs)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/samy/code/llama/llama/lib/python3.12/site-packages/transformers/configuration_utils.py", line 629, in _get_config_dict
    resolved_config_file = cached_file(
                           ^^^^^^^^^^^^
  File "/home/samy/code/llama/llama/lib/python3.12/site-packages/transformers/utils/hub.py", line 421, in cached_file
    raise EnvironmentError(
OSError: You are trying to access a gated repo.
Make sure to have access to it at https://huggingface.co/meta-llama/Llama-2-7b-hf.
403 Client Error. (Request ID: Root=1-67084e74-4f3982ed357bc458054902e2;e467bd73-847d-470f-8dc9-fead3ad9c1c6)
```